### PR TITLE
Items for release 0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,18 +31,19 @@ interfaces and visualization of results. These can be run directly if you have c
 installed the packaged version it is easiest to copy-paste the source code from Github (you will want to remove the
 automated path add code at the very top of the demo file as the 'gerabaldi' import should already work without it).
 
-Note that the VTS paper demos will take a significant amount of time to run due to the size of the simulations, these
-can be reduced by changing the three globals near the tops of the files as follows:
+Note that the VTS paper demos will require modification and take a significant amount of time to obtain the exact
+results shown due to the size of the simulations, to run the full simulations change the three globals near the tops of
+the files as follows:
 
-For demo 1:
-`NUM_SAMPLES = 5`
-`NUM_DEVICES = 5`
-`NUM_LOTS = 5`
+For demo 1 (pre-silicon variability analysis):
+`NUM_DEVICES = 10`
+`NUM_CHIPS = 10`
+`NUM_LOTS = 10`
 
-For demo 2:
-`TEST_LEN = 24 * 7 * 52 * 2`
-`NUM_SAMPLES = 100`
-`C_LATENT = 4e-5`
+For demo 2 (TDDB model sensitivity):
+`TEST_LEN = 24 * 7 * 52 * 20`
+`NUM_SAMPLES = 1000`
+`C_LATENT = 4e-6`
 
 Running the simulations with these values will provide similar-looking results but with far less computation and is
 useful for quickly seeing these more complex simulations in action.

--- a/demos/basic_use.py
+++ b/demos/basic_use.py
@@ -24,7 +24,7 @@ SECONDS_PER_HOUR = 3600
 NUM_DEVICES = 5
 
 
-def simulate(save_file: str = None):
+def run_simulation(save_file: str = None):
     """
     Demonstration of the simplest use of Gerabaldi, useful as a template and starting point for building your own sims.
     """
@@ -32,7 +32,7 @@ def simulate(save_file: str = None):
     ########################################################################
     ### 1. Define the test to simulate                                   ###
     ########################################################################
-    meas_spec = MeasSpec({'example': NUM_DEVICES}, {'temp': 25 + CELSIUS_TO_KELVIN})
+    meas_spec = MeasSpec({'example_prm': NUM_DEVICES}, {'temp': 25 + CELSIUS_TO_KELVIN})
     strs_spec = StrsSpec({'temp': 125 + CELSIUS_TO_KELVIN}, 100)
     test_spec = TestSpec([meas_spec, strs_spec, meas_spec])
 
@@ -47,7 +47,7 @@ def simulate(save_file: str = None):
     def ex_eqn(time, temp, a):
         return time * -a * temp
     dev_mdl = DeviceMdl(
-        {'example': DegPrmMdl(
+        {'example_prm': DegPrmMdl(
             {'linear': DegMechMdl(ex_eqn, a=LatentVar(Normal(1e-3, 2e-4)))})})
 
     ########################################################################
@@ -76,7 +76,7 @@ def visualize(report):
     measured = measured.set_index(['param', 'device #'])
     measured = measured.sort_index()
     for smpl in range(NUM_DEVICES):
-        meas = measured.loc[('example', smpl)]
+        meas = measured.loc[('example_prm', smpl)]
         p1.plot(meas['time'], meas['measured'], color=colours[smpl])
 
     # Set some plot properties for a clean look
@@ -93,7 +93,7 @@ def entry(data_file, save_data):
         report = TestSimReport(file=data_file)
     else:
         data_file = os.path.join(os.path.dirname(__file__), f"data/{DATA_FILE_NAME}.json") if save_data else None
-        report = simulate(save_file=data_file)
+        report = run_simulation(save_file=data_file)
     visualize(report)
 
 

--- a/demos/riverbed_erosion.py
+++ b/demos/riverbed_erosion.py
@@ -27,7 +27,7 @@ SAMPLES_PER_RIVER = 10
 RIVERS_SAMPLED = 5
 
 
-def simulate(save_file: str = None):
+def run_simulation(save_file: str = None):
     """
     Demonstration of using Gerabaldi's advanced stochastic model and degradation model agnosticism to simulate
     degradation of other processes beyond integrated circuits; in this case fluvial erosion in rivers.
@@ -37,13 +37,14 @@ def simulate(save_file: str = None):
     ### 1. Define the fluvial erosion stress and monitoring process/test ###
     ########################################################################
     # Note that 'tau' is the shear stress due to the flow of river water over the soil bed
+    # We will measure/sample 10 individual locations in the river for each measurement
     erosion_meas = MeasSpec({'riverbed_level': SAMPLES_PER_RIVER}, {'tau': 3}, 'Bed Height Sampling')
     # Each stress phase lasts a quarter of a year
     summer_strs = StrsSpec({'tau': 4}, HOURS_PER_YEAR / 4, 'Summer Season Flow')
     autumn_strs = StrsSpec({'tau': 2}, HOURS_PER_YEAR / 4, 'Autumn Season Flow')
     winter_strs = StrsSpec({'tau': 2}, HOURS_PER_YEAR / 4, 'Winter Season Flow')
     spring_strs = StrsSpec({'tau': 7}, HOURS_PER_YEAR / 4, 'Spring Season Flow')
-    # We will measure 20 individual locations in 5 different rivers for 10 years
+    # We will monitor 5 different rivers for 10 years
     ten_year_test = TestSpec([erosion_meas], RIVERS_SAMPLED, 1, name='Riverbed Erosion Process')
     ten_year_test.append_steps([spring_strs, summer_strs, autumn_strs, winter_strs, erosion_meas], HOURS_PER_YEAR * 10)
 
@@ -74,8 +75,10 @@ def simulate(save_file: str = None):
         prm_name='riverbed_level',
         deg_mech_mdls={
             'erosion': DegMechMdl(
-                fluvial_erosion_riverbed, k_d=LatentVar(deter_val=1e-5),
-                tau_c=LatentVar(Normal(2.4, 0.02), Normal(1, 0.2)), alpha=LatentVar(Normal(0.9, 0.01), Normal(1, 0.04)),
+                fluvial_erosion_riverbed,
+                k_d=LatentVar(deter_val=1e-5),
+                tau_c=LatentVar(Normal(2.4, 0.02), Normal(1, 0.2)),
+                alpha=LatentVar(Normal(0.9, 0.01), Normal(1, 0.04)),
             )},
         init_val_mdl=InitValMdl(init_val=LatentVar(dev_vrtn_mdl=Normal(-2, 0.01), chp_vrtn_mdl=Normal(1, 0.02))),
         compute_eqn=riverbed_level,
@@ -150,7 +153,7 @@ def entry(data_file, save_data):
         report = TestSimReport(file=data_file)
     else:
         data_file = os.path.join(os.path.dirname(__file__), f"data/{DATA_FILE_NAME}.json") if save_data else None
-        report = simulate(save_file=data_file)
+        report = run_simulation(save_file=data_file)
     visualize(report)
 
 

--- a/demos/vts_paper_tddb_model_sensitivity.py
+++ b/demos/vts_paper_tddb_model_sensitivity.py
@@ -29,9 +29,10 @@ DATA_FILES = {1.05: 'tddb_1.05_report', 1.075: 'tddb_1.075_report', 1.1: 'tddb_1
 CELSIUS_TO_KELVIN = 273.15
 SECONDS_PER_HOUR = 3600
 
-TEST_LEN = 24 * 7 * 52 * 20
-NUM_SAMPLES = 1000
-C_LATENT = 4e-6
+# To obtain results shown in the VTS paper, set TEST_LEN = 24 * 7 * 52 * 20, NUM_SAMPLES = 1000, C_LATENT = 4e-6
+TEST_LEN = 24 * 7 * 52 * 2
+NUM_SAMPLES = 100
+C_LATENT = 4e-5
 
 
 def defect_generator_demo_model(time, temp, v_g, t_diel, c, bond_strength, thermal_dist):
@@ -94,7 +95,7 @@ def single_test(step_val, test):
     return gerabaldi.simulate(test, tddb_model, field_env)
 
 
-def simulate(save_files: dict = None):
+def run_simulation(save_files: dict = None):
     """
     Demonstration of using Gerabaldi's support for hard failure mechanisms and arbitrary custom models to simulate TDDB
     failures using a custom-defined, non-algebraic model.
@@ -206,7 +207,7 @@ def entry(data_dir, save_data):
     else:
         data_files = {test: os.path.join(os.path.dirname(__file__), f"data/{DATA_FILES[test]}.json")
                       for test in DATA_FILES} if save_data else None
-        rprts = simulate(save_files=data_files)
+        rprts = run_simulation(save_files=data_files)
     visualize(rprts)
 
 

--- a/gerabaldi/__init__.py
+++ b/gerabaldi/__init__.py
@@ -42,7 +42,7 @@ simulate - The main procedure for the module, uses the above three models to run
 """
 
 # This value determines the project version for PyPi as well
-__version__ = '0.1.0'
+__version__ = '0.1.2'
 
 from . import models
 from . import cookbook

--- a/gerabaldi/cookbook/test_envs.py
+++ b/gerabaldi/cookbook/test_envs.py
@@ -39,7 +39,7 @@ def volt_and_temp_env() -> PhysTestEnv:
 
     # Voltmeter shows to nearest mV, noise error offsets of 0.2mV, range of 0V to 12V
     volt_meas = MeasInstrument(precision=3, error=Normal(0, 0.0002), meas_lims=(0, 12), name='Basic Voltmeter')
-    # Temperature shows to nearest hundreths of a degree, error offset of 0.2K and converts to Celsius, range -40 to 180
+    # Temperature to nearest hundredths of a degree, error offset of 0.2K and converts to Celsius, range -40 to 180
     temp_meas = MeasInstrument(precision=2, error=Normal(-273.15, 0.2), meas_lims=(-40, 180), name='Basic Temp Sensor')
 
     return PhysTestEnv(env_vrtns={'temp': temp_vrtns, 'vdd': volt_vrtns},

--- a/gerabaldi/cookbook/test_specs.py
+++ b/gerabaldi/cookbook/test_specs.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2023 Ian Hill
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from datetime import timedelta
 
 from gerabaldi.models.test_specs import MeasSpec, StrsSpec, TestSpec
@@ -11,8 +13,9 @@ __all__ = ['htol']
 CELSIUS_TO_KELVIN = 273.15
 
 
-def htol(to_meas: dict[str, int], vdd_nom: float = 1.0, vdd_strs_mult: float = 1.2,
-         strs_meas_intrvl: int = 1000) -> TestSpec:
+def htol(to_meas: dict[str, int], vdd_nom: float = 1.0, vdd_strs_mult: float = 1.2, strs_meas_intrvl: int = 1000,
+         duration_override: int = 1000, num_chps_override: int = 77, num_lots_override: int = 3,
+         temp_override: int = 125) -> TestSpec:
     """
     Build an HTOL test in a single function call for use in Gerabaldi simulations
 
@@ -26,6 +29,14 @@ def htol(to_meas: dict[str, int], vdd_nom: float = 1.0, vdd_strs_mult: float = 1
         The stress factor that 'vdd_nom' is multiplied by to get the HTOL stress voltage (default 1.2)
     strs_meas_intrvl: int, optional
         If provided, measurements under stress conditions will be made every 'strs_meas_intrvl' hours during the test
+    duration_override: int, optional
+        If provided, use the number of hours specified as the total test length instead of the HTOL default of 1000
+    num_chps_override: int, optional
+        If provided, use the number of chips specified instead of the HTOL default of 77
+    num_lots_override: int, optional
+        If provided, use the number of lots specified instead of the HTOL default of 3
+    temp_override: int, optional
+        If provided, stress at the passed temperature (in Celsius) instead of the HTOL default of 125
 
     Returns
     -------
@@ -33,8 +44,8 @@ def htol(to_meas: dict[str, int], vdd_nom: float = 1.0, vdd_strs_mult: float = 1
         The configured HTOL test specification model
     """
     # Define some HTOL test constants
-    htol_duration, htol_num_chips, htol_num_lots = 1000, 77, 3
-    room_temp_c, strs_temp_c = 25, 125
+    htol_duration, htol_num_chips, htol_num_lots = duration_override, num_chps_override, num_lots_override
+    room_temp_c, strs_temp_c = 25, temp_override
     room_vdd, strs_vdd = vdd_nom, vdd_nom * vdd_strs_mult
 
     meas_strs = MeasSpec(to_meas, {'temp': strs_temp_c + CELSIUS_TO_KELVIN, 'vdd': strs_vdd}, 'Stress Temp Measurement')
@@ -45,7 +56,7 @@ def htol(to_meas: dict[str, int], vdd_nom: float = 1.0, vdd_strs_mult: float = 1
                          description='A typical HTOL test with configurable measurements during stress.')
 
     # Include the option to take periodic measurements at the elevated stress conditions during the test
-    if strs_meas_intrvl >= 1000:
+    if strs_meas_intrvl >= htol_duration:
         htol_test.append_steps(htol_strs)
     else:
         if htol_duration % strs_meas_intrvl != 0:

--- a/gerabaldi/models/phys_envs.py
+++ b/gerabaldi/models/phys_envs.py
@@ -3,6 +3,8 @@
 
 """Classes for defining physical noise sources and measurement capabilities in a test environment."""
 
+from __future__ import annotations
+
 from math import floor, log10
 import numpy as np
 import pandas as pd

--- a/gerabaldi/models/random_vars.py
+++ b/gerabaldi/models/random_vars.py
@@ -4,6 +4,8 @@
 """Custom generators for random variables used for experiment simulation and model specification. Necessary as the Numpy
 and PyMC RVs either cannot be persisted or futz about with tensor types."""
 
+from __future__ import annotations
+
 import numpy as np
 
 from gerabaldi.helpers import _on_demand_import
@@ -33,15 +35,14 @@ class RandomVar:
             self._generator = getattr(np.random.default_rng(), self._dist_type)
 
     def _get_dist_params(self, target: str = 'pymc'):
-        match target:
-            case 'pymc':
-                return self._params_for_pymc()
-            case 'numpy':
-                return self._params_for_numpy()
-            case 'pyro':
-                return self._params_for_pyro()
-            case _:
-                raise NotImplementedError(f"Invalid target library {target} requested.")
+        if target == 'pymc':
+            return self._params_for_pymc()
+        elif target == 'numpy':
+            return self._params_for_numpy()
+        elif target == 'pyro':
+            return self._params_for_pyro()
+        else:
+            raise NotImplementedError(f"Invalid target library {target} requested.")
 
     def sample(self, quantity: int = 1) -> np.ndarray:
         """

--- a/gerabaldi/models/states.py
+++ b/gerabaldi/models/states.py
@@ -3,6 +3,8 @@
 
 """Custom classes for simulation state persistence"""
 
+from __future__ import annotations
+
 from datetime import timedelta
 from copy import deepcopy
 

--- a/gerabaldi/models/test_specs.py
+++ b/gerabaldi/models/test_specs.py
@@ -3,6 +3,8 @@
 
 """Classes for defining wear-out tests in terms of conditions, durations, execution steps, and collected data"""
 
+from __future__ import annotations
+
 from datetime import timedelta
 
 from gerabaldi.exceptions import UserConfigError

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=66.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
-packages = ["gerabaldi"]
+packages = ["gerabaldi", "gerabaldi.models", "gerabaldi.cookbook"]
 
 [project]
 name = "gerabaldi"
@@ -13,7 +13,7 @@ authors = [
 ]
 description = "A temporal simulator for probabilistic degradation and failure processes with a focus on integrated circuit wear-out "
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.7"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: Apache Software License",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,8 @@
 
 """Helper classes and functions to improve testing of stochastic methods."""
 
+from __future__ import annotations
+
 import pytest # noqa: PackageNotInRequirements
 import numpy as np
 

--- a/tests/unit_tests/top_level_test.py
+++ b/tests/unit_tests/top_level_test.py
@@ -65,18 +65,20 @@ def test_sim_stress_step_basic():
     report = TestSimReport(test_spec)
 
     # Run the function being tested
-    _sim_stress_step(stress_step, phys_state, deg_model, test_env, report)
+    _sim_stress_step(stress_step, phys_state, deg_model, test_env, report, 1)
 
     # Check types and returned values
     assert type(phys_state) == TestSimState
     assert round(phys_state.elapsed.total_seconds() / SECONDS_PER_HOUR, 2) == 20.00
     assert round(phys_state.curr_prm_vals['current'][0][1][2], 5) == 0.00556
-    assert report.stress_summary['stress step'][0] == 'unspecified'
-    assert report.stress_summary['temp'][0] == 125
+    assert report.test_summary['step name'][0] == 'unspecified'
+    assert report.test_summary['step type'][0] == 'stress'
+    assert report.test_summary['step number'][0] == 1
+    assert report.test_summary['temp'][0] == 125
 
     # Run again to check that the equivalent time back-calculations are working fine
-    _sim_stress_step(stress_step, phys_state, deg_model, test_env, report)
-    assert report.stress_summary['duration'][1] == timedelta(hours=20)
+    _sim_stress_step(stress_step, phys_state, deg_model, test_env, report, 2)
+    assert report.test_summary['duration'][1] == timedelta(hours=20)
     assert round(phys_state.curr_prm_vals['current'][0][1][2], 5) == 0.00570
 
 
@@ -103,13 +105,17 @@ def test_sim_meas_step_basic(sequential_var):
     deg_state = gerabaldi.gen_init_state(sim_model, dev_counts={'current': 10}, elapsed_time=10, num_chps=2)
     report = TestSimReport(test_spec)
 
-    _sim_meas_step(meas_step, deg_state, sim_model, test_env, report)
+    _sim_meas_step(meas_step, deg_state, sim_model, test_env, report, 3)
     assert type(report.measurements) == pd.DataFrame
     assert np.round(report.measurements['measured'][0], 5) == 120
     assert report.measurements['param'][0] == 'temp'
     assert np.round(report.measurements['measured'][2], 5) == 1.051
     assert report.measurements['chip #'][16] == 1
+    assert report.measurements['step #'][16] == 3
     assert np.round(report.measurements['measured'][12], 5) == 1.183
+    assert report.test_summary['step name'][0] == 'test_meas_spec'
+    assert report.test_summary['step type'][0] == 'measure'
+    assert report.test_summary['step number'][0] == 3
 
 
 def test_wearout_test_sim_basic():
@@ -132,7 +138,7 @@ def test_wearout_test_sim_basic():
     report = gerabaldi.simulate(test, deg_model, test_env, init_state)
     assert type(report) == TestSimReport
     assert len(report.measurements['param']) == 57
-    assert len(report.stress_summary['stress step']) == 2
+    assert len(report.test_summary['step number']) == 5
     assert round(report.measurements['measured'][40], 5) == 0.00560
     assert round(report.measurements['measured'][26], 5) == 0.00783
 


### PR DESCRIPTION
NEW FEATURES:

Now supports Python3.7 and up instead of only 3.10 and up

Modified report structure, adding measure step summary reporting and associating measurements with a measure step by number


MINOR CHANGES:

Added default value overrides for the cookbook HTOL test builder

Changed default behaviour of the two VTS demos to run the reduced size simulations, updated the documentation to reflect this change and correct device/chip/lot terminology


BUG FIXES:

Fixed pyproject.toml packages listing so that models and cookbook are correctly built

Fixed bug in gen_init_state where the function couldn't handle situations where stress conditions were included in the dictionary of parameters to measure

Fixed bug in LatentVar class where distribution names were being set incorrectly and made more compatible for CBI transpilation